### PR TITLE
Update vpn-limits.md

### DIFF
--- a/doc_source/vpn-limits.md
+++ b/doc_source/vpn-limits.md
@@ -6,7 +6,8 @@ Your AWS account has the following quotas, formerly referred to as limits, relat
 
   You can attach only one virtual private gateway to a VPC at a time\. 
 + Routes advertised to a Site\-to\-Site VPN connection from a customer gateway device: 100
-
+  Routes (Dynamic BGP/propagated) advertised to a Site\-to\-Site VPN connection (toward Virtual Private Gateway or Transit Gateway) from a customer gateway device: 100
+ 
   This quota cannot be increased\.
 + Routes advertised by a Site\-to\-Site VPN connection to a customer gateway device: 1000
 

--- a/doc_source/vpn-limits.md
+++ b/doc_source/vpn-limits.md
@@ -6,7 +6,7 @@ Your AWS account has the following quotas, formerly referred to as limits, relat
 
   You can attach only one virtual private gateway to a VPC at a time\. 
 + Routes advertised to a Site\-to\-Site VPN connection from a customer gateway device: 100
-  Routes (Dynamic BGP/propagated) advertised to a Site\-to\-Site VPN connection (toward Virtual Private Gateway or Transit Gateway) from a customer gateway device: 100
+  Routes (dynamic BGP/propagated) advertised to a Site\-to\-Site VPN connection (toward a virtual private gateway or transit gateway) from a customer gateway device: 100
  
   This quota cannot be increased\.
 + Routes advertised by a Site\-to\-Site VPN connection to a customer gateway device: 1000


### PR DESCRIPTION
Made 2 minor updates to the sentence to improve the clarity as the current sentence leave confusion with the end users:

1) Added that this is for Dynamic/BGP based routes and not Static. No where in the original sentence call out whether this limit is for static or dynamic/BGP based routing.
2) Added that this limit apply to Site-to-Site VPN connections made to both VGW (Virtual Private Gateway) or TGW (Transit Gateway), since VPN connections can be made to both depending upon the choice. Some customers don't know that TGW only support 10,000 static routes (not dynamic/BGP based) and the way original sentence is written create a lot of unnecessary confusion.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
