### PR TITLE
Update accelerated-vpn.md

### DIFF
--- a/doc_source/accelerated-vpn.md
+++ b/doc_source/accelerated-vpn.md
@@ -2,7 +2,7 @@
 
 You can optionally enable acceleration for your Site\-to\-Site VPN connection\. An accelerated Site\-to\-Site VPN connection \(accelerated VPN connection\) uses AWS Global Accelerator to route traffic from your on\-premises network to an AWS edge location that is closest to your customer gateway device\. AWS Global Accelerator optimizes the network path, using the congestion\-free AWS global network to route traffic to the endpoint that provides the best application performance \(for more information, see [AWS Global Accelerator](https://aws.amazon.com/global-accelerator/)\)\. You can use an accelerated VPN connection to avoid network disruptions that might occur when traffic is routed over the public internet\.
 
-When you create an accelerated VPN connection, we create and manage two accelerators on your behalf, one for each VPN tunnel\.
+When you create an accelerated VPN connection, we create and manage two accelerators on your behalf, one for each VPN tunnel\. Note: each tunnel uses a separate accelerator and a separate pool of IP addresses for the tunnel endpoint IP addresses. These accelerators are not visible in the AWS Console (AWS Global Accelerator->Accelerators page).
 
 Acceleration is only supported for Site\-to\-Site VPN connections that are attached to a transit gateway\. Virtual private gateways do not support accelerated VPN connections\.
 

--- a/doc_source/accelerated-vpn.md
+++ b/doc_source/accelerated-vpn.md
@@ -2,7 +2,7 @@
 
 You can optionally enable acceleration for your Site\-to\-Site VPN connection\. An accelerated Site\-to\-Site VPN connection \(accelerated VPN connection\) uses AWS Global Accelerator to route traffic from your on\-premises network to an AWS edge location that is closest to your customer gateway device\. AWS Global Accelerator optimizes the network path, using the congestion\-free AWS global network to route traffic to the endpoint that provides the best application performance \(for more information, see [AWS Global Accelerator](https://aws.amazon.com/global-accelerator/)\)\. You can use an accelerated VPN connection to avoid network disruptions that might occur when traffic is routed over the public internet\.
 
-When you create an accelerated VPN connection, we create and manage two accelerators on your behalf, one for each VPN tunnel\. Note: each tunnel uses a separate accelerator and a separate pool of IP addresses for the tunnel endpoint IP addresses. These accelerators are not visible in the AWS Console (AWS Global Accelerator->Accelerators page).
+When you create an accelerated VPN connection, we create and manage two accelerators on your behalf, one for each VPN tunnel. You cannot view or manage these accelerators yourself by using the AWS Global Accelerator console or APIs\.
 
 Acceleration is only supported for Site\-to\-Site VPN connections that are attached to a transit gateway\. Virtual private gateways do not support accelerated VPN connections\.
 


### PR DESCRIPTION
1) Added for clarity that one GA from a separate IP pool is created per VPN tunnel and
2) These GA are not visible in the console and are only available for use for VPN tunnels. This is to avoid any confusion as many users think that just because accelerated VPN create two GAs, a) they are visible in the console and b) can be used like other normal GA functions, which is not true/not the case.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
