### PR TITLE
Note for GovCloud regions on VPN config options

### DIFF
--- a/doc_source/VPNTunnels.md
+++ b/doc_source/VPNTunnels.md
@@ -65,6 +65,9 @@ Default: ::/0
 The DH group numbers that are permitted for the VPN tunnel for phase 1 of the IKE negotiations\. You can specify one or more of the default values\.  
 Default: 2, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
 
+**Note**  
+GovCloud regions have a minimum requirement of AES128, SHA2 and Diffie\-Hellman \(DH\) Group 14. 
+
 **Phase 2 Diffie\-Hellman \(DH\) group numbers**  
 The DH group numbers that are permitted for the VPN tunnel for phase 2 of the IKE negotiations\. You can specify one or more of the default values\.  
 Default: 2, 5, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24


### PR DESCRIPTION
GovCloud has undocumented requirements for VPNs even though unsupported options are available on the frontend. The only place these requirements are documented seems to be in the comments of the configuration exports.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
